### PR TITLE
    Try to silence annoying errors like

### DIFF
--- a/lib/Mojo/Redis2.pm
+++ b/lib/Mojo/Redis2.pm
@@ -6,7 +6,7 @@ Mojo::Redis2 - Pure-Perl non-blocking I/O Redis driver
 
 =head1 VERSION
 
-0.24
+0.241
 
 =head1 DESCRIPTION
 
@@ -129,7 +129,7 @@ use Carp ();
 use constant DEBUG => $ENV{MOJO_REDIS_DEBUG} || 0;
 use constant DEFAULT_PORT => 6379;
 
-our $VERSION = '0.24';
+our $VERSION = '0.241';
 
 my $PROTOCOL_CLASS = do {
   my $class = $ENV{MOJO_REDIS_PROTOCOL}
@@ -471,7 +471,7 @@ sub _connect {
       $stream->timeout(0);
       $stream->on(close => sub { $self and $self->_error($c) });
       $stream->on(error => sub { $self and $self->_error($c, $_[1]) });
-      $stream->on(read => sub { $self->_read($c, $_[1]) });
+      $stream->on(read => sub { $self and $self->_read($c, $_[1]) });
 
       # NOTE: unshift() will cause AUTH to be sent before SELECT
       unshift @{$c->{queue}}, [undef, SELECT => $db]          if $db;


### PR DESCRIPTION
    EventLoop error: I/O watcher failed: Can't call method "_read" on an undefined value at /home/git/regentmarkets/cpan/local/lib/perl5/Mojo/Redis2.pm line 474.